### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Continuous Integration
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions: read-all
+
+jobs:
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.4
+        with:
+          node-version: '20'
+      - name: Clean install of dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Create ci.yml to run builds on PRs and new commits to 'main'.

The job "unit-tests" will be modified later to *actually* run unit tests (and other relevant checks, like linting).  We can add future jobs to this later, such as integration tests against multiple node / os versions.