### PR TITLE
Improve metadata format listing for Android List command

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -29,6 +29,7 @@ import { createLogger, LogLevel } from '../utils/logger';
 import { fetchAndroidMappingMetadata, uploadFileAndroid } from '../utils/httpUtils';
 import { AxiosError } from 'axios';
 import { createSpinner } from '../utils/spinner';
+import { formatAndroidMappingMetadata } from '../utils/metadataFormatUtils';
 
 export const androidCommand = new Command('android');
 
@@ -379,7 +380,7 @@ androidCommand
     try {
       logger.debug(`URL Endpoint: ${url}`);
       const responseData = await fetchAndroidMappingMetadata({ url, token });
-      logger.info('Uploaded mapping file metadata:', JSON.stringify(responseData, null, 2));
+      logger.info(formatAndroidMappingMetadata(responseData));
     } catch (error) {
       logger.error('Failed to fetch metadata:', error);
       throw error;

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -18,6 +18,7 @@ import axios from 'axios';
 import fs from 'fs';
 import FormData from 'form-data';
 import { Logger } from '../utils/logger';
+import { AndroidMappingMetadata } from './metadataFormatUtils';
 
 interface FileUpload {
   filePath: string;
@@ -92,14 +93,14 @@ export const handleAxiosError = (
   }
 };
 
-export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMetadataOptions): Promise<string[]> => {
+export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMetadataOptions): Promise<AndroidMappingMetadata[]> => {
   const headers = {
     'X-SF-Token': token,
     'Accept': 'application/json',
   };
 
   try {
-    const response = await axios.get(url, { headers });
+    const response = await axios.get<AndroidMappingMetadata[]>(url, { headers });
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/utils/metadataFormatUtils.ts
+++ b/src/utils/metadataFormatUtils.ts
@@ -47,7 +47,6 @@ export function formatAndroidMappingMetadata(metadataList: AndroidMappingMetadat
         Uploaded: ${uploadDate}
         File Size: ${formatFileSize(item.fileSize)}
         Format Version: ${item.r8MappingFileFormatVersion || 'N/A'}
-        File URI: ${item.fileUri}
         `;
   }).join('\n' + '-'.repeat(50) + '\n');
   

--- a/src/utils/metadataFormatUtils.ts
+++ b/src/utils/metadataFormatUtils.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+export interface AndroidMappingMetadata {
+  id: number;
+  orgId: number;
+  appId: string;
+  appVersion: number;
+  createdOnMs: number;
+  updatedOnMs: number;
+  preprocessedVersion?: number;
+  fileUri: string;
+  createdBy?: number;
+  updatedBy?: number;
+  r8MappingFileFormatVersion?: string;
+  fileSize?: number;
+}
+  
+export function formatAndroidMappingMetadata(metadataList: AndroidMappingMetadata[]): string {
+  if (!metadataList || metadataList.length === 0) {
+    return 'No mapping files found.';
+  }
+  
+  // Create formatted table-like output
+  const formattedOutput = metadataList.map(item => {
+
+    // Make timestamps readable
+    const uploadDate = new Date(item.createdOnMs).toLocaleString();
+      
+    // Format each item
+    return `
+        ID: ${item.id}
+        App: ${item.appId} (Version: ${item.appVersion})
+        Uploaded: ${uploadDate}
+        File Size: ${formatFileSize(item.fileSize)}
+        Format Version: ${item.r8MappingFileFormatVersion || 'N/A'}
+        File URI: ${item.fileUri}
+        `;
+  }).join('\n' + '-'.repeat(50) + '\n');
+  
+  const summary = `Found ${metadataList.length} mapping file(s):\n` + '='.repeat(50);
+    
+  return summary + '\n' + formattedOutput;
+}
+  
+function formatFileSize(bytes?: number): string {
+  if (bytes === undefined) return 'Unknown';
+    
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let unitIndex = 0;
+    
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+    
+  return `${size.toFixed(2)} ${units[unitIndex]}`;
+}


### PR DESCRIPTION
Old vs new format.

![Screenshot 2025-04-08 at 12 48 55 PM](https://github.com/user-attachments/assets/e3532efd-b9d0-492c-a1cf-07c98d1a8159)
![Screenshot 2025-04-08 at 12 49 05 PM](https://github.com/user-attachments/assets/309ec3d7-de54-4ed1-b135-02a2ed648bff)

Added a metadataFormatUtils class and using it to format the metadata received from the backend