### PR TITLE
DEMRUM-1874: add formatting for iOS list subcommand

### DIFF
--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -21,6 +21,7 @@ import { createSpinner } from '../utils/spinner';
 import { createLogger, LogLevel } from '../utils/logger';
 import { validateDSYMsPath, cleanupTemporaryZips, getZippedDSYMs } from '../dsyms/iOSdSYMUtils';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
+import { IOSdSYMMetadata, formatIOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { COMMON_ERROR_MESSAGES } from '../utils/inputValidations';
 
 interface UploadCommandOptions {
@@ -225,12 +226,13 @@ iOSCommand
     });
 
     try {
-      await listDSYMs({
+      const responseData: IOSdSYMMetadata[] = await listDSYMs({
         url,
         token: token as string,
         logger,
         TOKEN_HEADER,
       });
+      logger.info(formatIOSdSYMMetadata(responseData));
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -72,7 +72,6 @@ export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams
         [TOKEN_HEADER]: token,
       },
     });
-    logger.info('Raw Response Data:', JSON.stringify(response.data, null, 2));
     return response.data; // Return the data if successful
   } catch (error) {
     const operationMessage = 'Unable to fetch the list of uploaded files.';

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -19,6 +19,7 @@ import { handleAxiosError } from '../utils/httpUtils';
 import fs from 'fs';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
+import { IOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 
 interface UploadParams {
@@ -63,15 +64,16 @@ interface ListParams {
   TOKEN_HEADER: string;
 }
 
-export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams): Promise<void> {
+export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams): Promise<IOSdSYMMetadata[]> {
   try {
-    const response = await axios.get(url, {
+    const response = await axios.get<IOSdSYMMetadata[]>(url, {
       headers: {
         'Content-Type': 'application/json',
         [TOKEN_HEADER]: token,
       },
     });
     logger.info('Raw Response Data:', JSON.stringify(response.data, null, 2));
+    return response.data; // Return the data if successful
   } catch (error) {
     const operationMessage = 'Unable to fetch the list of uploaded files.';
     const result = handleAxiosError(error, operationMessage, url, logger);
@@ -80,5 +82,7 @@ export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams
       Please check your network connection or try again later.`;
       throw new UserFriendlyError(error, userFriendlyMessage);
     }
+    logger.error('Unhandled error occurred while fetching dSYMs.');
+    return [];
   }
 }

--- a/src/utils/metadataFormatUtils.ts
+++ b/src/utils/metadataFormatUtils.ts
@@ -28,6 +28,19 @@ export interface AndroidMappingMetadata {
   r8MappingFileFormatVersion?: string;
   fileSize?: number;
 }
+
+export interface IOSdSYMMetadata {
+  machoId: string;
+  orgId: number;
+  libraryName: string;
+  createdOnMs: number;
+  updatedOnMs: number;
+  fileUri: string;
+  fileSize: number;
+  uploadUserAgent: string;
+  createdBy: number;
+  updatedBy: number;
+}
   
 export function formatAndroidMappingMetadata(metadataList: AndroidMappingMetadata[]): string {
   if (!metadataList || metadataList.length === 0) {
@@ -51,6 +64,30 @@ export function formatAndroidMappingMetadata(metadataList: AndroidMappingMetadat
   }).join('\n' + '-'.repeat(50) + '\n');
   
   const summary = `Found ${metadataList.length} mapping file(s):\n` + '='.repeat(50);
+    
+  return summary + '\n' + formattedOutput;
+}
+
+export function formatIOSdSYMMetadata(metadataList: IOSdSYMMetadata[]): string {
+  if (!metadataList || metadataList.length === 0) {
+    return 'No dSYM files found.';
+  }
+  
+  // Create formatted table-like output
+  const formattedOutput = metadataList.map(item => {
+    // Make timestamps readable
+    const uploadDate = new Date(item.createdOnMs).toLocaleString();
+      
+    // Format each item
+    return `
+        Library Name: ${item.libraryName}
+        MachO ID: ${item.machoId}
+        Uploaded: ${uploadDate}
+        File Size: ${formatFileSize(item.fileSize)}
+        `;
+  }).join('\n' + '-'.repeat(50) + '\n');
+  
+  const summary = `Found ${metadataList.length} dSYM file(s):\n` + '='.repeat(50);
     
   return summary + '\n' + formattedOutput;
 }


### PR DESCRIPTION
Add formatting for iOS list command following the example of the approach used in Android.

Did not use a unified approach because with the per-platform configuration for that we would end up having as much code or possibly even more code, and less clear, than we do with a per-platform-formatter approach.

Before:

```
Fetching dSYM file data
Raw Response Data: [
  {
    "machoId": "39cf578b-9f71-3aa0-a59e-69b062c351f5",
    "orgId": 477610686596251650,
    "libraryName": "cloudkart.debug.dylib",
    "createdOnMs": 1741976100660,
    "updatedOnMs": 1744404086123,
    "fileUri": "rum-symbol-mapping-lab0--splunk-com/symbol-files/477610686596251648/dsym/mach-o/39cf578b-9f71-3aa0-a59e-69b062c351f5",
    "fileSize": 9313392,
    "uploadUserAgent": "axios/1.8.2",
    "createdBy": -1,
    "updatedBy": -1
  },
...
```
After:

```
Fetching dSYM file data
Found 10 dSYM file(s):
==================================================

        Library Name: cloudkart.debug.dylib
        MachO ID: 39cf578b-9f71-3aa0-a59e-69b062c351f5
        Uploaded: 3/14/2025, 11:15:00 AM
        File Size: 8.88 MB
        
--------------------------------------------------
...
```
