### PR TITLE
fix(sourcemaps): always exclude node_modules folder

### DIFF
--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -44,7 +44,7 @@ export async function readdirRecursive(dir: string, include: string | string[] =
   const partialPaths = await glob(include, {
     cwd: dir,
     nodir: true,
-    ignore: exclude
+    ignore: ['**/node_modules/**', ...exclude]
   });
   return partialPaths.map(partialPath => path.join(dir, partialPath));
 }


### PR DESCRIPTION
prevent injecting or uploading unnecessary files if user passes project root as --path, instead of the build output directory