### PR TITLE
Feature/demrum 2027 add filename

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -24,6 +24,11 @@ import {
   isValidSplunkBuildId,
   COMMON_ERROR_MESSAGES
 } from '../utils/inputValidations';
+import {
+  BASE_URL_PREFIX,
+  API_VERSION_STRING,
+  ANDROID_CONSTANTS
+} from '../utils/constants';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { createLogger, LogLevel } from '../utils/logger';
 import { fetchAndroidMappingMetadata, uploadFileAndroid } from '../utils/httpUtils';
@@ -34,7 +39,7 @@ import { formatAndroidMappingMetadata } from '../utils/metadataFormatUtils';
 export const androidCommand = new Command('android');
 
 const generateURL = (type: 'upload' | 'list', realm: string, appId: string, versionCode?: string, splunkBuildId?: string): string => {
-  const baseUrl = `https://api.${realm}.signalfx.com/v2/rum-mfm/proguard`;
+  const baseUrl = `${BASE_URL_PREFIX}.${realm}.signalfx.com/${API_VERSION_STRING}/${ANDROID_CONSTANTS.PATH_FOR_UPLOAD}`;
 
   if (type === 'upload') {
     if (!versionCode) throw new Error('Version code is required for uploading.');

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -147,9 +147,11 @@ iOSCommand
       let failedUploads = 0;
 
       for (const filePath of zipFiles) {
+        const fileName = basename(filePath);
         try {
           await uploadDSYM({
             filePath,
+	    fileName,
             url,
             token: token as string,
             logger,

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 import { basename } from 'path';
 import { Command } from 'commander';
@@ -154,7 +154,6 @@ iOSCommand
             token: token as string,
             logger,
             spinner,
-            TOKEN_HEADER,
           });
         } catch (error) {
           failedUploads++;

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -16,6 +16,7 @@
 
 import { Command } from 'commander';
 import { createSpinner } from '../utils/spinner';
+import { IOS_CONSTANTS } from '../utils/constants';
 import { uploadDSYMZipFiles, listDSYMs } from '../dsyms/dsymClient';
 import { createLogger, LogLevel } from '../utils/logger';
 import { generateUrl, prepareUploadFiles } from '../dsyms/iOSdSYMUtils';
@@ -37,10 +38,6 @@ interface ListCommandOptions {
   token?: string;
   debug?: boolean;
 }
-
-// Constants
-const API_PATH_FOR_LIST = 'rum-mfm/macho/metadatas';
-const TOKEN_HEADER = 'X-SF-Token';
 
 const program = new Command();
 export const iOSCommand = program.command('ios');
@@ -136,8 +133,7 @@ iOSCommand
     logger.info('Fetching dSYM file data');
 
     const url = generateUrl({
-      urlPrefix: 'https://api',
-      apiPath: API_PATH_FOR_LIST,
+      apiPath: IOS_CONSTANTS.PATH_FOR_METADATA,
       realm: options.realm
     });
 
@@ -146,7 +142,6 @@ iOSCommand
         url,
         token: token as string,
         logger,
-        TOKEN_HEADER,
       });
       logger.info(formatIOSdSYMMetadata(responseData));
     } catch (error) {

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
 */
 
-import { basename } from 'path';
 import { Command } from 'commander';
-import { uploadDSYM, listDSYMs } from '../dsyms/dsymClient';
 import { createSpinner } from '../utils/spinner';
+import { uploadDSYMZipFiles, listDSYMs } from '../dsyms/dsymClient';
 import { createLogger, LogLevel } from '../utils/logger';
-import { validateDSYMsPath, cleanupTemporaryZips, getZippedDSYMs } from '../dsyms/iOSdSYMUtils';
+import { generateUrl, prepareUploadFiles } from '../dsyms/iOSdSYMUtils';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { IOSdSYMMetadata, formatIOSdSYMMetadata } from '../utils/metadataFormatUtils';
-import { COMMON_ERROR_MESSAGES } from '../utils/inputValidations';
+import { COMMON_ERROR_MESSAGES, validateAndPrepareToken } from '../utils/inputValidations';
 
 interface UploadCommandOptions {
   path: string;
@@ -32,6 +31,7 @@ interface UploadCommandOptions {
   dryRun?: boolean;
 }
 
+
 interface ListCommandOptions {
   realm: string;
   token?: string;
@@ -39,37 +39,18 @@ interface ListCommandOptions {
 }
 
 // Constants
-const API_VERSION_STRING = 'v2';
 const API_PATH_FOR_LIST = 'rum-mfm/macho/metadatas';
-const API_PATH_FOR_UPLOAD = 'rum-mfm/dsym';
 const TOKEN_HEADER = 'X-SF-Token';
 
 const program = new Command();
 export const iOSCommand = program.command('ios');
 
 const shortDescription = 'Upload and list iOS symbolication files (dSYMs)';
-
 const detailedHelp = `For each respective command listed below under 'Commands', please run 'splunk-rum ios <command> --help' for an overview of its usage and options`;
-
 const iOSUploadDescription = `This subcommand uploads dSYMs provided as either a zip file, or a dSYM or dSYMs directory.`;
-
 const listdSYMsDescription = `This subcommand retrieves and shows a list of the uploaded dSYMs.
 By default, it returns the last 100 dSYMs uploaded, sorted in reverse chronological order based on the upload timestamp.
 `;
-
-const generateUrl = ({
-  urlPrefix,
-  apiPath,
-  realm,
-  domain = 'signalfx.com',
-}: {
-  urlPrefix: string;
-  apiPath: string;
-  realm: string;
-  domain?: string;
-}): string => {
-  return `${urlPrefix}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
-};
 
 iOSCommand
   .description(shortDescription)
@@ -86,7 +67,6 @@ iOSCommand
   .showHelpAfterError(COMMON_ERROR_MESSAGES.HELP_MESSAGE_AFTER_ERROR)
   .usage('--path <dSYMs directory or zip file>')
   .description(iOSUploadDescription)
-  .summary('Upload dSYMs, either by directory path or zip path, to the symbolication service')
   .requiredOption('--path <dSYMs dir or zip>', 'Path to the dSYM[s] directory or zip file.')
   .requiredOption(
     '--realm <value>',
@@ -100,82 +80,26 @@ iOSCommand
   .option('--debug', 'Enable debug logs')
   .option('--dry-run', 'Perform a trial run with no changes made', false)
   .action(async (options: UploadCommandOptions) => {
-    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
-    if (!token) {
-      iOSCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
-    }
-    options.token = token;
-
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
 
     try {
-      const dsymsPath = options.path;
+      // Step 1: Validate and prepare the token
+      const token = validateAndPrepareToken(options);
 
-      // Validate that the provided path fits one of our expected patterns for dSYMs
-      const absPath = validateDSYMsPath(dsymsPath);
+      // Step 2: Validate the input path and prepare the zipped files
+      const { zipFiles, uploadPath } = prepareUploadFiles(options.path, logger);
 
-      // Get the list of zipped dSYM files
-      const { zipFiles, uploadPath } = getZippedDSYMs(absPath, logger);
-
-      // If dry-run mode is enabled, log the actions and exit early
-      if (options.dryRun) {
-        if (zipFiles.length === 0) {
-          logger.info(`Dry run mode: No files found to upload for directory: ${dsymsPath}.`);
-        } else {
-          const descriptor = zipFiles.length === 1 ? 'file' : 'files';
-          logger.info(`Dry run mode: Would upload the following ${descriptor}:`);
-          zipFiles.forEach((filePath) => {
-            const fileName = basename(filePath);
-            logger.info(`\t${fileName}`);
-          });
-        }
-        cleanupTemporaryZips(uploadPath);
-        return;
-      }
-
-      // Get the URL for the upload endpoint
-      const url = generateUrl({
-        urlPrefix: 'https://api',
-        apiPath: API_PATH_FOR_UPLOAD,
-        realm: options.realm
+      // Step 3: Upload the files
+      await uploadDSYMZipFiles({
+        zipFiles,
+        uploadPath,
+        realm: options.realm,
+        token,
+        logger,
+        spinner: createSpinner(),
       });
-      logger.info(`url: ${url}`);
 
-      logger.info(`Preparing to upload dSYMs files from directory: ${dsymsPath}`);
-
-      const spinner = createSpinner();
-      let failedUploads = 0;
-
-      for (const filePath of zipFiles) {
-        const fileName = basename(filePath);
-        try {
-          await uploadDSYM({
-            filePath,
-	    fileName,
-            url,
-            token: token as string,
-            logger,
-            spinner,
-          });
-        } catch (error) {
-          failedUploads++;
-          if (error instanceof UserFriendlyError) {
-            logger.error(error.message);
-          } else {
-            logger.error('Unknown error during upload');
-          }
-        }
-      }
-
-      // Perform cleanup before final reporting
-      cleanupTemporaryZips(uploadPath);
-
-      // Report failed uploads if there are any
-      if (failedUploads > 0) {
-        iOSCommand.error(`Upload failed for ${failedUploads} file${failedUploads !== 1 ? 's' : ''}`);
-      } else {
-        logger.info('All files uploaded successfully.');
-      }
+      logger.info('All files uploaded successfully.');
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 import { basename } from 'path';
 import { Command } from 'commander';
@@ -143,14 +143,9 @@ iOSCommand
 
       logger.info(`Preparing to upload dSYMs files from directory: ${dsymsPath}`);
 
-      const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
-      if (!token) {
-        iOSCommand.error('Error: API access token is required.');
-      }
-
-      let failedUploads = 0;
       const spinner = createSpinner();
-      
+      let failedUploads = 0;
+
       for (const filePath of zipFiles) {
         try {
           await uploadDSYM({
@@ -165,12 +160,8 @@ iOSCommand
           failedUploads++;
           if (error instanceof UserFriendlyError) {
             logger.error(error.message);
-            cleanupTemporaryZips(uploadPath);
-            iOSCommand.error(error.message);
           } else {
             logger.error('Unknown error during upload');
-            cleanupTemporaryZips(uploadPath);
-            iOSCommand.error('Unknown error during upload');
           }
         }
       }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -44,7 +44,8 @@ export const iOSCommand = program.command('ios');
 
 const shortDescription = 'Upload and list iOS symbolication files (dSYMs)';
 const detailedHelp = `For each respective command listed below under 'Commands', please run 'splunk-rum ios <command> --help' for an overview of its usage and options`;
-const iOSUploadDescription = `This subcommand uploads dSYMs provided as either a zip file, or a dSYM or dSYMs directory.`;
+const iOSUploadDescription = 'This subcommand uploads dSYMs provided as either a zip file, or a dSYM or dSYMs directory.';
+const iOSUploadSummary = 'Upload dSYMs, either by directory path or zip path, to the symbolication service';
 const listdSYMsDescription = `This subcommand retrieves and shows a list of the uploaded dSYMs.
 By default, it returns the last 100 dSYMs uploaded, sorted in reverse chronological order based on the upload timestamp.
 `;
@@ -64,6 +65,7 @@ iOSCommand
   .showHelpAfterError(COMMON_ERROR_MESSAGES.HELP_MESSAGE_AFTER_ERROR)
   .usage('--path <dSYMs directory or zip file>')
   .description(iOSUploadDescription)
+  .summary(iOSUploadSummary)
   .requiredOption('--path <dSYMs dir or zip>', 'Path to the dSYM[s] directory or zip file.')
   .requiredOption(
     '--realm <value>',

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -25,27 +25,29 @@ import { IOSdSYMMetadata } from '../utils/metadataFormatUtils';
 
 interface UploadParams {
   filePath: string;
+  fileName: string;
   url: string;
   token: string;
   logger: Logger;
   spinner: Spinner;
 }
 
-export async function uploadDSYM({ filePath, url, token, logger, spinner }: UploadParams): Promise<void> {
-  const fileName = basename(filePath);
+export async function uploadDSYM({ filePath, fileName, url, token, logger, spinner }: UploadParams): Promise<void> {
 
+  console.log(`debug: fileName is ${fileName}`);
+  
   spinner.start(`Uploading file: ${filePath}`);
 
   try {
     await uploadFile({
       url,
-      token,
       file: {
         filePath,
         fieldName: 'file',
       },
+      token,
       parameters: {
-        filename: fileName,
+        'filename': fileName,
       },
       onProgress: ({ progress, loaded, total }) => {
         spinner.updateText(`Uploading ${filePath}: ${progress.toFixed(2)}% (${loaded}/${total} bytes)`);

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -16,6 +16,7 @@
 
 import axios from 'axios';
 import { uploadFile } from '../utils/httpUtils';
+import { TOKEN_HEADER, IOS_CONSTANTS } from '../utils/constants';
 import { generateUrl } from './iOSdSYMUtils';
 import { basename } from 'path';
 import { handleAxiosError } from '../utils/httpUtils';
@@ -26,7 +27,6 @@ import { IOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { cleanupTemporaryZips } from './iOSdSYMUtils';
 
 
-const API_PATH_FOR_UPLOAD = 'rum-mfm/dsym';
 
 // for the group of all file uploads
 interface UploadDSYMZipFilesOptions {
@@ -60,8 +60,7 @@ export async function uploadDSYMZipFiles({
   spinner,
 }: UploadDSYMZipFilesOptions): Promise<void> {
   const url = generateUrl({
-    urlPrefix: 'https://api',
-    apiPath: API_PATH_FOR_UPLOAD,
+    apiPath: IOS_CONSTANTS.PATH_FOR_UPLOAD,
     realm,
   });
   logger.info(`url: ${url}`);
@@ -141,10 +140,9 @@ interface ListParams {
   url: string;
   token: string;
   logger: Logger;
-  TOKEN_HEADER: string;
 }
 
-export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams): Promise<IOSdSYMMetadata[]> {
+export async function listDSYMs({ url, token, logger }: ListParams): Promise<IOSdSYMMetadata[]> {
   try {
     const response = await axios.get<IOSdSYMMetadata[]>(url, {
       headers: {

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -12,8 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
+import axios from 'axios';
 import { uploadFile } from '../utils/httpUtils';
 import { basename } from 'path';
 import { handleAxiosError } from '../utils/httpUtils';
@@ -28,10 +29,9 @@ interface UploadParams {
   token: string;
   logger: Logger;
   spinner: Spinner;
-  TOKEN_HEADER: string;
 }
 
-export async function uploadDSYM({ filePath, url, token, logger, spinner, TOKEN_HEADER }: UploadParams): Promise<void> {
+export async function uploadDSYM({ filePath, url, token, logger, spinner }: UploadParams): Promise<void> {
   const fileName = basename(filePath);
 
   spinner.start(`Uploading file: ${filePath}`);

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -22,8 +22,8 @@ import { basename } from 'path';
 import { handleAxiosError } from '../utils/httpUtils';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
-import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { IOSdSYMMetadata } from '../utils/metadataFormatUtils';
+import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { cleanupTemporaryZips } from './iOSdSYMUtils';
 
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -41,7 +41,6 @@ interface UploadDSYMZipFilesOptions {
 // for a single upload
 interface UploadParams {
   filePath: string;
-  fileName: string;
   url: string;
   token: string;
   logger: Logger;
@@ -70,11 +69,9 @@ export async function uploadDSYMZipFiles({
 
   try {
     for (const filePath of zipFiles) {
-      const fileName = basename(filePath);
       try {
         await uploadDSYM({
           filePath,
-          fileName,
           url,
           token,
           logger,
@@ -100,10 +97,8 @@ export async function uploadDSYMZipFiles({
   }
 }
 
-export async function uploadDSYM({ filePath, fileName, url, token, logger, spinner }: UploadParams): Promise<void> {
+export async function uploadDSYM({ filePath, url, token, logger, spinner }: UploadParams): Promise<void> {
 
-  console.log(`debug: fileName is ${fileName}`);
-  
   spinner.start(`Uploading file: ${filePath}`);
 
   try {
@@ -114,9 +109,7 @@ export async function uploadDSYM({ filePath, fileName, url, token, logger, spinn
         fieldName: 'file',
       },
       token,
-      parameters: {
-        'filename': fileName,
-      },
+      parameters: {},
       onProgress: ({ progress, loaded, total }) => {
         spinner.updateText(`Uploading ${filePath}: ${progress.toFixed(2)}% (${loaded}/${total} bytes)`);
       },

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -120,7 +120,7 @@ export async function uploadDSYM({ filePath, url, token, logger, spinner }: Uplo
     const result = handleAxiosError(error, operationMessage, url, logger);
 
     if (result) {
-      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection, realm, and token values, and ensure the file size does not exceed the limit.`;
+      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection or your realm and token values, and ensure the file size does not exceed the limit.`;
       throw new UserFriendlyError(error, userFriendlyMessage);
     }
   }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -86,12 +86,10 @@ export async function uploadDSYMZipFiles({
       }
     }
 
-    // Handle failed uploads
     if (failedUploads > 0) {
       throw new Error(`Upload failed for ${failedUploads} file${failedUploads !== 1 ? 's' : ''}`);
     }
   } finally {
-    // Always cleanup temporary files
     cleanupTemporaryZips(uploadPath);
   }
 }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -18,7 +18,6 @@ import axios from 'axios';
 import { uploadFile } from '../utils/httpUtils';
 import { TOKEN_HEADER, IOS_CONSTANTS } from '../utils/constants';
 import { generateUrl } from './iOSdSYMUtils';
-import { basename } from 'path';
 import { handleAxiosError } from '../utils/httpUtils';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -21,6 +21,26 @@ import { join, resolve, basename, dirname } from 'path';
 import { copyFileSync, mkdtempSync, readdirSync, rmSync, statSync } from 'fs';
 import { UserFriendlyError, throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 
+// Constants
+export const API_VERSION_STRING = 'v2';
+
+/**
+ * Helper function to generate API URLs.
+ */
+export const generateUrl = ({
+  urlPrefix,
+  apiPath,
+  realm,
+  domain = 'signalfx.com',
+}: {
+  urlPrefix: string;
+  apiPath: string;
+  realm: string;
+  domain?: string;
+}): string => {
+  return `${urlPrefix}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
+};
+
 /**
  * Helper functions for locating and zipping dSYMs
  **/
@@ -70,6 +90,24 @@ export function validateDSYMsPath(dsymsPath: string): string {
   }
 
   throw new UserFriendlyError(null, `Invalid input: Expected a path named 'dSYMs' or ending in '.dSYM', '.dSYMs.zip', or '.dSYM.zip'.`);
+}
+
+/**
+ * Validate the input path and prepare zipped files.
+ */
+export function prepareUploadFiles(dsymsPath: string, logger: Logger): { zipFiles: string[]; uploadPath: string } {
+  const absPath = validateDSYMsPath(dsymsPath);
+
+  // Get the list of zipped dSYM files
+  const { zipFiles, uploadPath } = getZippedDSYMs(absPath, logger);
+
+  // Log files for dry-run mode
+  if (zipFiles.length === 0) {
+    logger.info(`No files found to upload for directory: ${dsymsPath}.`);
+    throw new Error('No files to upload.');
+  }
+
+  return { zipFiles, uploadPath };
 }
 
 /**

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -16,29 +16,25 @@
 
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
+import { BASE_URL_PREFIX, API_VERSION_STRING } from '../utils/constants';
 import { Logger } from '../utils/logger';
 import { join, resolve, basename, dirname } from 'path';
 import { copyFileSync, mkdtempSync, readdirSync, rmSync, statSync } from 'fs';
 import { UserFriendlyError, throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 
-// Constants
-export const API_VERSION_STRING = 'v2';
-
 /**
  * Helper function to generate API URLs.
  */
 export const generateUrl = ({
-  urlPrefix,
   apiPath,
   realm,
   domain = 'signalfx.com',
 }: {
-  urlPrefix: string;
   apiPath: string;
   realm: string;
   domain?: string;
 }): string => {
-  return `${urlPrefix}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
+  return `${BASE_URL_PREFIX}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
 };
 
 /**

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -20,6 +20,11 @@ import {
   isJsFilePath,
   isJsMapFilePath
 } from './utils';
+import {
+  BASE_URL_PREFIX,
+  API_VERSION_STRING,
+  SOURCEMAPS_CONSTANTS
+} from '../utils/constants';
 import { throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 import { discoverJsMapFilePath } from './discoverJsMapFilePath';
 import { computeSourceMapId } from './computeSourceMapId';
@@ -264,8 +269,9 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
 }
 
 function getSourceMapUploadUrl(realm: string, idPathParam: string): string {
-  const API_BASE_URL = `https://api.${realm}.signalfx.com`;
-  return `${API_BASE_URL}/v2/rum-mfm/source-maps/id/${idPathParam}`;
+  const API_BASE_URL = `${BASE_URL_PREFIX}.${realm}.signalfx.com`;
+  const PATH_FOR_SOURCEMAPS = SOURCEMAPS_CONSTANTS.PATH_FOR_UPLOAD;
+  return `${API_BASE_URL}/${API_VERSION_STRING}/${PATH_FOR_SOURCEMAPS}/id/${idPathParam}`;
 }
 
 function throwDirectoryReadErrorDuringInject(err: unknown, directory: string): never {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/*
+ * Centralized constants for the Splunk RUM CLI.
+ */
+
+// Global Constants
+export const API_VERSION_STRING = 'v2';
+export const BASE_URL_PREFIX = 'https://api';
+export const TOKEN_HEADER = 'X-SF-Token';
+
+// Android-Specific Constants
+export const ANDROID_CONSTANTS = {
+  PATH_FOR_UPLOAD: 'rum-mfm/proguard',
+  PATH_FOR_METADATA: 'rum-mfm/proguard/metadatas',
+};
+
+// iOS-Specific Constants
+export const IOS_CONSTANTS = {
+  PATH_FOR_UPLOAD: 'rum-mfm/dsym',
+  PATH_FOR_METADATA: 'rum-mfm/macho/metadatas',
+};
+
+// Sourcemaps-Specific Constants
+export const SOURCEMAPS_CONSTANTS = {
+  PATH_FOR_UPLOAD: 'rum-mfm/source-maps',
+  PATH_FOR_METADATA: 'rum-mfm/source-maps/metadatas',
+};
+
+// Debugging/Development Flags (if needed)
+export const DEBUG_CONSTANTS = {
+  ENABLE_LOGGING: true,
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -41,7 +41,3 @@ export const SOURCEMAPS_CONSTANTS = {
   PATH_FOR_METADATA: 'rum-mfm/source-maps/metadatas',
 };
 
-// Debugging/Development Flags (if needed)
-export const DEBUG_CONSTANTS = {
-  ENABLE_LOGGING: true,
-};

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -149,18 +149,11 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
 
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
+
   const ext = file.filePath.split('.').pop()?.toLowerCase();
   const fileSizeInBytes = fs.statSync(file.filePath).size;
-  
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
-  let contentType = 'application/json';
-  if (ext === 'gz') {
-    contentType = 'application/gzip'; 
-  } else if (ext === 'zip') {
-    contentType = 'application/zip';
-  }
-  
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
@@ -169,7 +162,6 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
-      'Content-Type': contentType,
       'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -150,9 +150,10 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
 
+  // Append the file to formData with the key 'file'
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
-  for (const [ key, value ] of Object.entries(parameters)) {
+  for (const [key, value] of Object.entries(parameters)) {
     formData.append(key, value);
   }
 
@@ -169,7 +170,7 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
       const progress = (loaded / total) * 100;
       if (onProgress) {
         onProgress({ progress, loaded, total });
-      }    
+      }
     },
   });
 };

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -119,8 +119,6 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
   
   if (ext === 'gz') {
     contentType = 'application/gzip'; 
-  } else if (ext === 'zip') {
-    contentType = 'application/zip';
   }
 
   const fileStream = fs.createReadStream(file.filePath);
@@ -151,19 +149,25 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
 
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
-
+  const ext = file.filePath.split('.').pop()?.toLowerCase();
+  const fileSizeInBytes = fs.statSync(file.filePath).size;
+  
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
+  let contentType = 'application/json';
+  if (ext === 'zip') {
+    formData.append('Content-Type', 'application/zip');
+  }
+  
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
-
-  const fileSizeInBytes = fs.statSync(file.filePath).size;
 
   await axios.put(url, formData, {
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
+      'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {
       const loaded = progressEvent.loaded;

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -150,19 +150,18 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
 
-  const ext = file.filePath.split('.').pop()?.toLowerCase();
-  const fileSizeInBytes = fs.statSync(file.filePath).size;
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
 
+  const fileSizeInBytes = fs.statSync(file.filePath).size;
+
   await axios.put(url, formData, {
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
-      'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {
       const loaded = progressEvent.loaded;

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -119,6 +119,8 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
   
   if (ext === 'gz') {
     contentType = 'application/gzip'; 
+  } else if (ext === 'zip') {
+    contentType = 'application/zip';
   }
 
   const fileStream = fs.createReadStream(file.filePath);

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -155,8 +155,10 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
   let contentType = 'application/json';
-  if (ext === 'zip') {
-    formData.append('Content-Type', 'application/zip');
+  if (ext === 'gz') {
+    contentType = 'application/gzip'; 
+  } else if (ext === 'zip') {
+    contentType = 'application/zip';
   }
   
   for (const [ key, value ] of Object.entries(parameters)) {
@@ -167,6 +169,7 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
+      'Content-Type': contentType,
       'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -150,10 +150,9 @@ export const uploadFileAndroid = async ({ url, file, token, onProgress }: Upload
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
 
-  // Append the file to formData with the key 'file'
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
-  for (const [key, value] of Object.entries(parameters)) {
+  for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
 

--- a/src/utils/inputValidations.ts
+++ b/src/utils/inputValidations.ts
@@ -48,3 +48,12 @@ export const isValidVersionCode = (versionCode: unknown): boolean => {
 export const isValidSplunkBuildId = (splunkBuildId: unknown | undefined): boolean => {
   return splunkBuildId !== undefined && typeof splunkBuildId === 'string' && splunkBuildId.length > 0;
 };
+
+// Validate token
+export function validateAndPrepareToken(options: { token?: string }): string {
+  const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
+  }
+  return token;
+}

--- a/src/utils/metadataFormatUtils.ts
+++ b/src/utils/metadataFormatUtils.ts
@@ -36,6 +36,7 @@ export interface IOSdSYMMetadata {
   createdOnMs: number;
   updatedOnMs: number;
   fileUri: string;
+  dsymFileName: string;
   fileSize: number;
   uploadUserAgent: string;
   createdBy: number;
@@ -81,6 +82,7 @@ export function formatIOSdSYMMetadata(metadataList: IOSdSYMMetadata[]): string {
     // Format each item
     return `
         Library Name: ${item.libraryName}
+        File Name: ${item.dsymFileName}
         MachO ID: ${item.machoId}
         Uploaded: ${uploadDate}
         File Size: ${formatFileSize(item.fileSize)}


### PR DESCRIPTION
* Update iOS upload to use common `uploadFile` function from `httpUtils`, which itself does a multipart/form-data upload
* Refactor iOS code to be more modular so the main `ios.ts` contains only the subcommands
* Introduce a `constants.ts` file with global constants and scoped constants in namespaces `ANDROID_CONSTANTS`, `IOS_CONSTANTS` and `SOURCEMAPS_CONSTANTS`
* Updated code in various files to use the new constants
* Update list command to show file name for iOS
* Tested against newly updated endpoint (Savin's work in DEMRUM-1993)