### PR TITLE
Feature/demrum 2045 error interceptors

### DIFF
--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 import { Command } from 'commander';
 import { createSpinner } from '../utils/spinner';

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -19,6 +19,7 @@ import { createSpinner } from '../utils/spinner';
 import { IOS_CONSTANTS } from '../utils/constants';
 import { uploadDSYMZipFiles, listDSYMs } from '../dsyms/dsymClient';
 import { createLogger, LogLevel } from '../utils/logger';
+import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { generateUrl, prepareUploadFiles } from '../dsyms/iOSdSYMUtils';
 import { IOSdSYMMetadata, formatIOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { COMMON_ERROR_MESSAGES, validateAndPrepareToken } from '../utils/inputValidations';

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -79,14 +79,14 @@ iOSCommand
   .option('--dry-run', 'Perform a trial run with no changes made', false)
   .action(async (options: UploadCommandOptions) => {
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
-      
+
     try {
       // Step 1: Validate and prepare the token
       const token = validateAndPrepareToken(options);
-	
+
       // Step 2: Validate the input path and prepare the zipped files
       const { zipFiles, uploadPath } = prepareUploadFiles(options.path, logger);
-    
+
       // Step 3: Upload the files
       await uploadDSYMZipFiles({
         zipFiles,
@@ -96,7 +96,7 @@ iOSCommand
         logger,
         spinner: createSpinner(),
       });
-    
+
       logger.info('All dSYM files uploaded successfully.');
     } catch (error) {
       if (error instanceof UserFriendlyError) {

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -100,7 +100,7 @@ iOSCommand
       logger.info('All dSYM files uploaded successfully.');
     } catch (error) {
       if (error instanceof UserFriendlyError) {
-        // UserFriendlyError.message already contains the formatted string from formatCliErrorMessage
+        // UserFriendlyError.message already contains the formatted string from formatCLIErrorMessage
         logger.error(error.message);
         if (options.debug && error.originalError) {
           logger.debug('Original error details:', error.originalError);
@@ -148,7 +148,7 @@ iOSCommand
 
     } catch (error) {
       if (error instanceof UserFriendlyError) {
-        // The UserFriendlyError.message is already formatted by formatCliErrorMessage
+        // The UserFriendlyError.message is already formatted by formatCLIErrorMessage
         // and includes both user-friendly text and technical details.
         // logger.error will prefix this with "ERROR " and handle colors.
         logger.error(error.message);

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -120,28 +120,16 @@ iOSCommand
         }
       }
 
-      // Perform cleanup before final reporting
       cleanupTemporaryZips(uploadPath);
 
-      // Report failed uploads if there are any
       if (failedUploads > 0) {
         iOSCommand.error(`Upload failed for ${failedUploads} file${failedUploads !== 1 ? 's' : ''}`);
       } else {
         logger.info('All files uploaded successfully.');
       }
-    } catch (error) {
-      if (error instanceof UserFriendlyError) {
-        logger.error(error.message);
-        iOSCommand.error(error.message);
-      } else {
-        logger.error('An unexpected error occurred:', error);
-        iOSCommand.error('An unexpected error occurred.');
-      }
-=======
-    } catch (error: any) { // Specify the type of the error object
+    } catch (error: any) {
       logger.error(error.message);
       iOSCommand.error(error.message);
->>>>>>> 0270054 (DEMRUM-2045: wip some refactoring to get iOS upload code to use the apiInterceptor)
     }
   });
 
@@ -179,7 +167,7 @@ iOSCommand
         logger,
       });
       logger.info(formatIOSdSYMMetadata(responseData));
-    } catch (error: any) { // Specify the type of the error object
+    } catch (error: any) {
       logger.error(error.message);
       iOSCommand.error(error.message);
     }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -106,7 +106,9 @@ iOSCommand
           logger.debug('Original error details:', error.originalError);
         }
       } else {
-        logger.error('An unexpected error occurred while running the ios subcommand:', error);
+        logger.error(
+          error instanceof Error ? error.message : `An unexpected error occurred: ${String(error)}`
+        );
       }
       iOSCommand.error(''); // ensure error exit code. process.exit(1) would also work.
     }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -144,7 +144,7 @@ iOSCommand
         logger,
       });
 
-      logger.info(formatIOSdSYMMetadata(responseData)); // log formatted data on success
+      logger.info(formatIOSdSYMMetadata(responseData));
 
     } catch (error) {
       if (error instanceof UserFriendlyError) {

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -135,7 +135,6 @@ iOSCommand
       } else {
         logger.info('All files uploaded successfully.');
       }
->>>>>>> fe43677 (DEMRUM-2027: wip for a multipart/form-data solution that adds filename)
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -99,6 +99,43 @@ iOSCommand
       });
 
       logger.info('All files uploaded successfully.');
+
+      logger.info(`Preparing to upload dSYMs files from directory: ${dsymsPath}`);
+
+      const spinner = createSpinner();
+      let failedUploads = 0;
+
+      for (const filePath of zipFiles) {
+        const fileName = basename(filePath);
+        try {
+          await uploadDSYM({
+            filePath,
+	    fileName,
+            url,
+            token: token as string,
+            logger,
+            spinner,
+          });
+        } catch (error) {
+          failedUploads++;
+          if (error instanceof UserFriendlyError) {
+            logger.error(error.message);
+          } else {
+            logger.error('Unknown error during upload');
+          }
+        }
+      }
+
+      // Perform cleanup before final reporting
+      cleanupTemporaryZips(uploadPath);
+
+      // Report failed uploads if there are any
+      if (failedUploads > 0) {
+        iOSCommand.error(`Upload failed for ${failedUploads} file${failedUploads !== 1 ? 's' : ''}`);
+      } else {
+        logger.info('All files uploaded successfully.');
+      }
+>>>>>>> fe43677 (DEMRUM-2027: wip for a multipart/form-data solution that adds filename)
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -106,7 +106,7 @@ iOSCommand
           logger.debug('Original error details:', error.originalError);
         }
       } else {
-        logger.error('An unexpected error occurred during the iOS command:', error);
+        logger.error('An unexpected error occurred while running the ios subcommand:', error);
       }
       iOSCommand.error(''); // ensure error exit code. process.exit(1) would also work.
     }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 import { Command } from 'commander';
 import { createSpinner } from '../utils/spinner';

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -10,6 +10,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
 */
 
 import { Command } from 'commander';
@@ -77,60 +79,23 @@ iOSCommand
   .action(async (options: UploadCommandOptions) => {
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
 
-    try {
-      // Step 1: Validate and prepare the token
-      const token = validateAndPrepareToken(options);
+    // Step 1: Validate and prepare the token
+    const token = validateAndPrepareToken(options);
 
-      // Step 2: Validate the input path and prepare the zipped files
-      const { zipFiles, uploadPath } = prepareUploadFiles(options.path, logger);
+    // Step 2: Validate the input path and prepare the zipped files
+    const { zipFiles, uploadPath } = prepareUploadFiles(options.path, logger);
 
-      // Step 3: Upload the files
-      await uploadDSYMZipFiles({
-        zipFiles,
-        uploadPath,
-        realm: options.realm,
-        token,
-        logger,
-        spinner: createSpinner(),
-      });
+    // Step 3: Upload the files
+    await uploadDSYMZipFiles({
+      zipFiles,
+      uploadPath,
+      realm: options.realm,
+      token,
+      logger,
+      spinner: createSpinner(),
+    });
 
-      logger.info(`Preparing to upload dSYMs files from directory: ${dsymsPath}`);
-
-      const spinner = createSpinner();
-      let failedUploads = 0;
-
-      for (const filePath of zipFiles) {
-        const fileName = basename(filePath);
-        try {
-          await uploadDSYM({
-            filePath,
-	    fileName,
-            url,
-            token: token as string,
-            logger,
-            spinner,
-          });
-        } catch (error) {
-          failedUploads++;
-          if (error instanceof UserFriendlyError) {
-            logger.error(error.message);
-          } else {
-            logger.error('Unknown error during upload');
-          }
-        }
-      }
-
-      cleanupTemporaryZips(uploadPath);
-
-      if (failedUploads > 0) {
-        iOSCommand.error(`Upload failed for ${failedUploads} file${failedUploads !== 1 ? 's' : ''}`);
-      } else {
-        logger.info('All files uploaded successfully.');
-      }
-    } catch (error: any) {
-      logger.error(error.message);
-      iOSCommand.error(error.message);
-    }
+    logger.info('All files uploaded successfully.');
   });
 
 iOSCommand
@@ -160,15 +125,12 @@ iOSCommand
       realm: options.realm
     });
 
-    try {
-      const responseData: IOSdSYMMetadata[] = await listDSYMs({
-        url,
-        token: token as string,
-        logger,
-      });
-      logger.info(formatIOSdSYMMetadata(responseData));
-    } catch (error: any) {
-      logger.error(error.message);
-      iOSCommand.error(error.message);
-    }
+    const responseData: IOSdSYMMetadata[] = await listDSYMs({
+      url,
+      token: token as string,
+      logger,
+    });
+    logger.info(formatIOSdSYMMetadata(responseData));
   });
+
+

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -19,8 +19,8 @@ import { createSpinner } from '../utils/spinner';
 import { IOS_CONSTANTS } from '../utils/constants';
 import { uploadDSYMZipFiles, listDSYMs } from '../dsyms/dsymClient';
 import { createLogger, LogLevel } from '../utils/logger';
-import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { generateUrl, prepareUploadFiles } from '../dsyms/iOSdSYMUtils';
+import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { IOSdSYMMetadata, formatIOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { COMMON_ERROR_MESSAGES, validateAndPrepareToken } from '../utils/inputValidations';
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -44,7 +44,6 @@ interface UploadParams {
   spinner: Spinner;
 }
 
-
 /**
  * Iterate over zipped files and upload them.
  */

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 import axios from 'axios';
 import { uploadFile } from '../utils/httpUtils';
@@ -21,11 +21,8 @@ import { generateUrl } from './iOSdSYMUtils';
 import { handleAxiosError } from '../utils/httpUtils';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
-import { IOSdSYMMetadata } from '../utils/metadataFormatUtils';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { cleanupTemporaryZips } from './iOSdSYMUtils';
-
-
 
 // for the group of all file uploads
 interface UploadDSYMZipFilesOptions {
@@ -120,7 +117,7 @@ export async function uploadDSYM({ filePath, url, token, logger, spinner }: Uplo
     const result = handleAxiosError(error, operationMessage, url, logger);
 
     if (result) {
-      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection or your realm and token values, and ensure the file size does not exceed the limit.`;
+      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection, realm, and token values, and ensure the file size does not exceed the limit.`;
       throw new UserFriendlyError(error, userFriendlyMessage);
     }
   }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -37,11 +37,13 @@ interface UploadDSYMZipFilesOptions {
 // for a single upload
 interface UploadParams {
   filePath: string;
+  fileName: string;
   url: string;
   token: string;
   logger: Logger;
   spinner: Spinner;
 }
+
 
 /**
  * Iterate over zipped files and upload them.
@@ -93,6 +95,8 @@ export async function uploadDSYMZipFiles({
 
 export async function uploadDSYM({ filePath, url, token, logger, spinner }: UploadParams): Promise<void> {
 
+  console.log(`debug: fileName is ${fileName}`);
+  
   spinner.start(`Uploading file: ${filePath}`);
 
   try {

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -129,8 +129,13 @@ export async function listDSYMs({ url, token, logger }: ListParams): Promise<IOS
     });
     return response.data;
   } catch (error) {
-    // The error is already a UserFriendlyError thrown by the interceptor
-    logger.error(`Error during list dSYMs: ${error.message}`);
-    throw error;
+    // apiInterceptor should always throw an error that has a .message property (UserFriendlyError).
+    if (error instanceof Error) {
+      logger.debug(`Error during list dSYMs: ${error.message}`); // already logged in non-debug at command level
+    } else {
+      // Fallback for truly unknown, non-Error types
+      logger.error(`An unknown error occurred during list dSYMs: ${String(error)}`);
+    }
+    throw error; // Re-throw to be caught by command-level handler
   }
 }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -98,7 +98,8 @@ export async function uploadDSYM({ filePath, fileName, url, token, logger, spinn
       'filename': fileName,
     },
     onProgress: ({ progress, loaded, total }) => {
-      spinner.updateText(`Uploading ${filePath}: ${progress.toFixed(2)}% (${loaded}/${total} bytes)`);
+      const progressText = `Uploading ${filePath}: ${progress.toFixed(2)}% (${loaded}/${total} bytes)`;
+      spinner.updateText(progress === 100 ? `${progressText}\n` : progressText);
     },
   }, axiosInstance);
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -83,7 +83,7 @@ export async function uploadDSYMZipFiles({
 }
 
 export async function uploadDSYM({ filePath, fileName, url, token, logger, spinner, axiosInstance }: UploadParams): Promise<void> {
-  logger.debug(`Uploading dSYM: ${fileName}`); // Changed from console.log
+  logger.debug(`Uploading dSYM: ${fileName}`);
   
   spinner.start(`Uploading file: ${filePath}`);
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 import axios from 'axios';
 import { uploadFile } from '../utils/httpUtils';

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -97,9 +97,13 @@ export async function uploadDSYM({ filePath, fileName, url, token, logger, spinn
     parameters: {
       'filename': fileName,
     },
-    onProgress: ({ progress, loaded, total }) => {
-      const progressText = `Uploading ${filePath}: ${progress.toFixed(2)}% (${loaded}/${total} bytes)`;
-      spinner.updateText(progress === 100 ? `${progressText}\n` : progressText);
+    onProgress: ({ total }) => {
+      if (total) {
+        spinner.updateText(`Uploading ${filePath}: Total size ${total} bytes.`);
+      } else {
+        // fallback
+        spinner.updateText(`Uploading ${filePath}...`);
+      }
     },
   }, axiosInstance);
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -60,7 +60,9 @@ export async function uploadDSYMZipFiles({
   logger.info(`Preparing to upload dSYMs files from directory: ${uploadPath}`);
 
   const axiosInstance = axios.create();
-  attachApiInterceptor(axiosInstance, logger, { userFriendlyMessage: 'An error occurred during dSYM upload.' });
+  attachApiInterceptor(axiosInstance, logger, url, { userFriendlyMessage: 'An error occurred during dSYM upload.' });
+
+  logger.debug(`uploadDSYMZipFiles has url: ${url}`);
 
   try {
     for (const filePath of zipFiles) {
@@ -120,7 +122,7 @@ interface ListParams {
 
 export async function listDSYMs({ url, token, logger }: ListParams): Promise<IOSdSYMMetadata[]> {
   const axiosInstance = axios.create();
-  attachApiInterceptor(axiosInstance, logger); // Interceptor will throw UserFriendlyError on API failure
+  attachApiInterceptor(axiosInstance, logger, url); // Interceptor will throw UserFriendlyError on API failure
   try {
     const response = await axiosInstance.get<IOSdSYMMetadata[]>(url, {
       headers: {

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -22,24 +22,19 @@ import { join, resolve, basename, dirname } from 'path';
 import { copyFileSync, mkdtempSync, readdirSync, rmSync, statSync } from 'fs';
 import { UserFriendlyError, throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 
-// Constants
-export const API_VERSION_STRING = 'v2';
-
 /**
  * Helper function to generate API URLs.
  */
 export const generateUrl = ({
-  urlPrefix,
   apiPath,
   realm,
   domain = 'signalfx.com',
 }: {
-  urlPrefix: string;
   apiPath: string;
   realm: string;
   domain?: string;
 }): string => {
-  return `${urlPrefix}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
+  return `${BASE_URL_PREFIX}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
 };
 
 /**

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -22,6 +22,26 @@ import { join, resolve, basename, dirname } from 'path';
 import { copyFileSync, mkdtempSync, readdirSync, rmSync, statSync } from 'fs';
 import { UserFriendlyError, throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 
+// Constants
+export const API_VERSION_STRING = 'v2';
+
+/**
+ * Helper function to generate API URLs.
+ */
+export const generateUrl = ({
+  urlPrefix,
+  apiPath,
+  realm,
+  domain = 'signalfx.com',
+}: {
+  urlPrefix: string;
+  apiPath: string;
+  realm: string;
+  domain?: string;
+}): string => {
+  return `${urlPrefix}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
+};
+
 /**
  * Helper function to generate API URLs.
  */

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -38,21 +38,6 @@ export const generateUrl = ({
 };
 
 /**
- * Helper function to generate API URLs.
- */
-export const generateUrl = ({
-  apiPath,
-  realm,
-  domain = 'signalfx.com',
-}: {
-  apiPath: string;
-  realm: string;
-  domain?: string;
-}): string => {
-  return `${BASE_URL_PREFIX}.${realm}.${domain}/${API_VERSION_STRING}/${apiPath}`;
-};
-
-/**
  * Helper functions for locating and zipping dSYMs
  **/
 export function validateDSYMsPath(dsymsPath: string): string {

--- a/src/utils/apiInterceptor.ts
+++ b/src/utils/apiInterceptor.ts
@@ -39,7 +39,7 @@ export function attachApiInterceptor(axiosInstance: AxiosInstance, logger: Logge
           userFriendlyMessage: options.userFriendlyMessage || `The server returned an error (${status}). Please check your input and try again.`,
         };
         if (status === 401) {
-          standardError.userFriendlyMessage = 'Error: API access token is required.';
+          standardError.userFriendlyMessage = 'API access token is required.';
         } else if (status === 404) {
           standardError.userFriendlyMessage = 'Resource not found. Please check the URL or resource ID.';
         } else if (status === 413) {

--- a/src/utils/apiInterceptor.ts
+++ b/src/utils/apiInterceptor.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import axios, { AxiosError } from 'axios';
+import { Logger } from './utils/logger';
+import { UserFriendlyError } from './utils/userFriendlyErrors';
+import { ErrorCategory, StandardError, formatCliErrorMessage } from './utils/httpUtils';
+
+export function attachApiInterceptor(axiosInstance: any, logger: Logger) {
+    axiosInstance.interceptors.response.use(
+        (response) => response,
+        (error: AxiosError) => {
+            let standardError: StandardError;
+
+            if (error.response) {
+                // HTTP Errors
+                const { status, data } = error.response;
+                standardError = {
+                    type: ErrorCategory.GeneralHttpError,
+                    message: `HTTP ${status}: ${error.message}`,
+                    details: {
+                        status: status,: API access token is required.';
+                } else if (status === 404) {
+                    standardError.userFriendlyMessage = 'Resource not found. Please check the URL or resource ID.';
+                } else if (status === 413) {
+                    standardError.type = ErrorCategory.RequestEntityTooLarge;
+                    standardError.userFriendlyMessage = 'The uploaded file is too large. Please reduce the file size and try again.';
+                }
+            } else if (error.request) {
+                // Transport Errors
+                standardError = {
+                    type: ErrorCategory.NoResponse,
+                    message: `No response received: ${error.message}`,
+                    userFriendlyMessage: 'Please check your network connection or try again later.';
+                };
+            } else {
+                // Unexpected Errors (Axios configuration, etc.)
+                standardError = {
+                    type: ErrorCategory.Unexpected,
+                    message: `Unexpected error: ${error.message}`,
+                    userFriendlyMessage: 'An unexpected error occurred.';
+                };
+            }
+
+            logger.error(standardError.message);
+            if (standardError.details) {
+                logger.debug('Error details:', standardError.details);
+            }
+
+            // Wrap the error in a UserFriendlyError for CLI display
+            throw new UserFriendlyError(error, formatCliErrorMessage(standardError));
+        }
+    );
+}
+

--- a/src/utils/apiInterceptor.ts
+++ b/src/utils/apiInterceptor.ts
@@ -35,7 +35,6 @@ export function attachApiInterceptor(
   axiosInstance.interceptors.response.use(
     (response) => response, // Pass through successful responses
     (error: AxiosError) => { // AxiosError's 'data' in response can be 'any' or 'unknown'
-      const isDebug = process.env.DEBUG === 'true';
       const { response: axiosResponse, request, code } = error;
 
       // Use the 'url' parameter passed to this function, as it's confirmed to be the full URL.
@@ -127,12 +126,10 @@ export function attachApiInterceptor(
       }
 
       // Log detailed error info in debug mode
-      if (isDebug) {
-        logger.debug('Error details:', {
-          message: standardError.message,
-          details: standardError.details,
-        });
-      }
+      logger.debug('Error details:', {
+        message: standardError.message,
+        details: standardError.details,
+      });
 
       // Throw the UserFriendlyError
       throw new UserFriendlyError(standardError, formatCLIErrorMessage(standardError));

--- a/src/utils/apiInterceptor.ts
+++ b/src/utils/apiInterceptor.ts
@@ -17,7 +17,7 @@
 import { AxiosError, AxiosInstance } from 'axios';
 import { Logger } from './logger';
 import { UserFriendlyError } from './userFriendlyErrors';
-import { ErrorCategory, StandardError, formatCliErrorMessage } from './httpUtils';
+import { ErrorCategory, StandardError, formatCLIErrorMessage } from './httpUtils';
 
 interface InterceptorOptions {
   userFriendlyMessage?: string;
@@ -77,7 +77,7 @@ export function attachApiInterceptor(axiosInstance: AxiosInstance, logger: Logge
         logger.debug('Error details:', standardError.details);
       }
 
-      throw new UserFriendlyError(error, formatCliErrorMessage(standardError));
+      throw new UserFriendlyError(error, formatCLIErrorMessage(standardError));
     }
   );
 }

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -124,8 +124,10 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
   let contentType = 'application/json';
-  if (ext === 'zip') {
-    formData.append('Content-Type', 'application/zip');
+  if (ext === 'gz') {
+    contentType = 'application/gzip'; 
+  } else if (ext === 'zip') {
+    contentType = 'application/zip';
   }
   
   for (const [ key, value ] of Object.entries(parameters)) {
@@ -136,6 +138,7 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
+      'Content-Type': contentType,
       'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -10,6 +10,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
 */
 
 import axios, { AxiosInstance } from 'axios';
@@ -141,6 +143,6 @@ export const mockUploadFile = async ({ file, onProgress }: UploadOptions): Promi
 export interface StandardError {
   type: ErrorCategory;
   message: string;
-  details?: any;
+  details?: { status: number; data: unknown; };
   userFriendlyMessage: string;
 }

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -57,7 +57,7 @@ export enum ErrorCategory {
   Unexpected = 'UNEXPECTED'
 }
 
-export function formatCliErrorMessage(error: StandardError): string {
+export function formatCLIErrorMessage(error: StandardError): string {
   return `Error: ${error.userFriendlyMessage}\nDetails: ${error.message}`;
 }
 

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -118,18 +118,11 @@ export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMe
 
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
+
   const ext = file.filePath.split('.').pop()?.toLowerCase();
   const fileSizeInBytes = fs.statSync(file.filePath).size;
-  
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
-  let contentType = 'application/json';
-  if (ext === 'gz') {
-    contentType = 'application/gzip'; 
-  } else if (ext === 'zip') {
-    contentType = 'application/zip';
-  }
-  
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
@@ -138,7 +131,6 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
-      'Content-Type': contentType,
       'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -118,19 +118,25 @@ export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMe
 
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
-
+  const ext = file.filePath.split('.').pop()?.toLowerCase();
+  const fileSizeInBytes = fs.statSync(file.filePath).size;
+  
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
+  let contentType = 'application/json';
+  if (ext === 'zip') {
+    formData.append('Content-Type', 'application/zip');
+  }
+  
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
-
-  const fileSizeInBytes = fs.statSync(file.filePath).size;
 
   await axios.put(url, formData, {
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
+      'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {
       const loaded = progressEvent.loaded;

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -54,7 +54,7 @@ export enum ErrorCategory {
   NetworkIssue = 'NETWORK_ISSUE',
   NoResponse = 'NO_RESPONSE',
   GeneralHttpError = 'GENERAL_HTTP_ERROR',
-  Unexpected = 'UNEXPECTED'
+  Unexpected = 'UNEXPECTED',
 }
 
 export function formatCLIErrorMessage(error: StandardError): string {
@@ -143,6 +143,10 @@ export const mockUploadFile = async ({ file, onProgress }: UploadOptions): Promi
 export interface StandardError {
   type: ErrorCategory;
   message: string;
-  details?: { status: number; data: unknown; };
+  details?: {
+    status?: number; // HTTP status code
+    data?: unknown; // Response data
+    url?: string; // URL that was attempted
+  };
   userFriendlyMessage: string;
 }

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -119,19 +119,18 @@ export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMe
 export const uploadFile = async ({ url, file, token, parameters, onProgress }: UploadOptions): Promise<void> => {
   const formData = new FormData();
 
-  const ext = file.filePath.split('.').pop()?.toLowerCase();
-  const fileSizeInBytes = fs.statSync(file.filePath).size;
   formData.append(file.fieldName, fs.createReadStream(file.filePath));
 
   for (const [ key, value ] of Object.entries(parameters)) {
     formData.append(key, value);
   }
 
+  const fileSizeInBytes = fs.statSync(file.filePath).size;
+
   await axios.put(url, formData, {
     headers: {
       ...formData.getHeaders(),
       [TOKEN_HEADER]: token,
-      'Content-Length': fileSizeInBytes,
     },
     onUploadProgress: (progressEvent) => {
       const loaded = progressEvent.loaded;


### PR DESCRIPTION
* Add Axios interceptors to project, to reduce boilerplate and improve consistency in error handling and formatting.
* Add an optional axiosInstance parameter to uploadFile()
* Add similar approach for listDSYMs()
* Remove redundant error message output lines
* Convert some redundant error messages to debug only
* Included some specific 4xx messages; we can extend the list.

This is working for iOS/dsyms as a PoC, which can act as a guide for other platforms.

Essentially: instead of using axios convenience methods like axios.get, we create an axios instance and attach an interceptor to it. We pass the instance into uploadFile, which makes equivalent calls on that instance. See code below. The current uploadFile should continue to work without the optional axiosInstance parameter in the meantime.

Also after making the change in how uploadFile (or your list function) is called, most error output code in the caller can be removed, as it will be handled by the interceptor.

Skeleton example from iOS:

```
  const axiosInstance = axios.create();
  // the message passed in below is only used as a fallback
  attachApiInterceptor(axiosInstance, logger, { userFriendlyMessage: 'An error occurred during dSYM upload.' });

  try {
    for (const filePath of zipFiles) {
      const fileName = basename(filePath);
      await uploadDSYM({
        filePath,
       ... other parameters ...
        spinner,
        axiosInstance,
      });
    }

  } finally {
     ...
  }
```

btw the commit history looks a bit long since I rebased this onto another branch anticipating that branch would get merged, which it did. Should have done some squashing somewhere along the line or similar cleanup.