### PR TITLE
Use multipart upload for Android, add filename to params, and to listing

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -201,7 +201,6 @@ androidCommand
           spinner.updateText(`Uploading: ${Math.round(progressData.progress)}%`);
         } : undefined
       });
-
       spinner.stop();
       logger.info(`Upload complete`);
     } catch (error) {
@@ -329,7 +328,6 @@ androidCommand
             spinner.updateText(`Uploading: ${Math.round(progressData.progress)}%`);
           } : undefined
         });
-   
         spinner.stop();
         logger.info(`Upload complete`);
       } catch (error) {
@@ -398,7 +396,6 @@ androidCommand
     try {
       logger.debug(`URL Endpoint: ${url}`);
       const responseData = await fetchAndroidMappingMetadata({ url, token });
-
       logger.info(formatAndroidMappingMetadata(responseData));
     } catch (error) {
       logger.error('Failed to fetch metadata:', error);

--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -31,10 +31,11 @@ import {
 } from '../utils/constants';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { createLogger, LogLevel } from '../utils/logger';
-import { fetchAndroidMappingMetadata, uploadFileAndroid } from '../utils/httpUtils';
+import { fetchAndroidMappingMetadata, uploadFile } from '../utils/httpUtils';
 import { AxiosError } from 'axios';
 import { createSpinner } from '../utils/spinner';
 import { formatAndroidMappingMetadata } from '../utils/metadataFormatUtils';
+import path from 'path';
 
 export const androidCommand = new Command('android');
 
@@ -189,12 +190,18 @@ androidCommand
     spinner.start(`Uploading Android mapping file: ${options.path}`);
 
     try {
-      await uploadFileAndroid({
+      await uploadFile({
         url: url,
         file: { filePath: options.path, fieldName: 'file' },
         token: options.token,
-        parameters: {}
+        parameters: { 
+          filename: path.basename(options.path)
+        },
+        onProgress: options.debug ? (progressData) => {
+          spinner.updateText(`Uploading: ${Math.round(progressData.progress)}%`);
+        } : undefined
       });
+
       spinner.stop();
       logger.info(`Upload complete`);
     } catch (error) {
@@ -311,12 +318,18 @@ androidCommand
       spinner.start(`Uploading Android mapping file: ${options.path}`);
       
       try {
-        await uploadFileAndroid({
+        await uploadFile({
           url: url,
           file: { filePath: options.path, fieldName: 'file' },
           token: options.token,
-          parameters: {}
+          parameters: { 
+            filename: path.basename(options.path)
+          },
+          onProgress: options.debug ? (progressData) => {
+            spinner.updateText(`Uploading: ${Math.round(progressData.progress)}%`);
+          } : undefined
         });
+   
         spinner.stop();
         logger.info(`Upload complete`);
       } catch (error) {
@@ -385,6 +398,7 @@ androidCommand
     try {
       logger.debug(`URL Endpoint: ${url}`);
       const responseData = await fetchAndroidMappingMetadata({ url, token });
+
       logger.info(formatAndroidMappingMetadata(responseData));
     } catch (error) {
       logger.error('Failed to fetch metadata:', error);

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -111,37 +111,6 @@ export const fetchAndroidMappingMetadata = async ({ url, token }: FetchAndroidMe
   }
 };
 
-export const uploadFileAndroid = async ({ url, file, token, onProgress }: UploadOptions): Promise<void> => {
-  const fileSizeInBytes = fs.statSync(file.filePath).size;
-
-  const ext = file.filePath.split('.').pop()?.toLowerCase();
-  let contentType = 'text/plain'; 
-  
-  if (ext === 'gz') {
-    contentType = 'application/gzip'; 
-  }
-
-  const fileStream = fs.createReadStream(file.filePath);
-
-  const headers = {
-    'Content-Type': contentType, 
-    [TOKEN_HEADER]: token, 
-    'Content-Length': fileSizeInBytes,
-  };
-
-  await axios.put(url, fileStream, {
-    headers,
-    onUploadProgress: (progressEvent) => {
-      const loaded = progressEvent.loaded;
-      const total = progressEvent.total || fileSizeInBytes;
-      const progress = (loaded / total) * 100;
-      if (onProgress) {
-        onProgress({ progress, loaded, total });
-      }
-    },
-  });
-};
-
 // This uploadFile method will be used by all the different commands that want to upload various types of
 // symbolication files to o11y cloud. The url, file, and additional parameters are to be prepared by the
 // calling method. Various errors, Error, axiosErrors and all should be handled by the caller of this method.
@@ -169,7 +138,7 @@ export const uploadFile = async ({ url, file, token, parameters, onProgress }: U
       const progress = (loaded / total) * 100;
       if (onProgress) {
         onProgress({ progress, loaded, total });
-      }
+      }    
     },
   });
 };

--- a/src/utils/metadataFormatUtils.ts
+++ b/src/utils/metadataFormatUtils.ts
@@ -27,6 +27,8 @@ export interface AndroidMappingMetadata {
   updatedBy?: number;
   r8MappingFileFormatVersion?: string;
   fileSize?: number;
+  fileName?: string;
+  buildId?: string;
 }
 
 export interface IOSdSYMMetadata {
@@ -56,8 +58,9 @@ export function formatAndroidMappingMetadata(metadataList: AndroidMappingMetadat
       
     // Format each item
     return `
-        ID: ${item.id}
-        App: ${item.appId} (Version: ${item.appVersion})
+        App: ${item.appId} (Version Code: ${item.appVersion})
+        File Name: ${item.fileName}
+        Splunk Build ID: ${item.buildId}
         Uploaded: ${uploadDate}
         File Size: ${formatFileSize(item.fileSize)}
         Format Version: ${item.r8MappingFileFormatVersion || 'N/A'}


### PR DESCRIPTION
- Use generic multipart uploadFile method for android uploads
- Remove unused uploadFileAndroid method 
- Pass in filename to upload params
- Add filename to listed metadata in list command
- tested with lab0