### PR TITLE
DEMRUM-2228: Rev alpha version to 0.0.1-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/rum-cli",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "Tools for handling symbol and mapping files for symbolication",
   "main": "./dist/index.js",
   "files": [


### PR DESCRIPTION
We need the latest update of the prerelease on npmjs so we can do a live screen recording for getting GTM team up to speed with install and usage.

This bumps the version from 0.0.1-alpha.3 to 0.0.1-alpha.4
