### PR TITLE
fix: create spinner-aware logger to more easily avoid jumbled logs

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -142,8 +142,8 @@ androidCommand
       androidCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
     }
 
-    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
     const spinner = createSpinner();
+    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO, spinner);
 
     logger.debug(`Validating App ID: ${options.appId}`);
     if (!isValidAppId(options.appId)) {
@@ -248,8 +248,8 @@ androidCommand
       androidCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
     }
 
-    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
     const spinner = createSpinner();
+    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO, spinner);
 
     try {
       logger.debug(`Validating Mapping File Path: ${options.path}`);
@@ -392,4 +392,3 @@ androidCommand
     }
   });
 
-  

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -78,7 +78,8 @@ iOSCommand
   .option('--debug', 'Enable debug logs')
   .option('--dry-run', 'Perform a trial run with no changes made', false)
   .action(async (options: UploadCommandOptions) => {
-    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
+    const spinner = createSpinner();
+    const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO, spinner);
 
     try {
       // Step 1: Validate and prepare the token
@@ -94,11 +95,12 @@ iOSCommand
         realm: options.realm,
         token,
         logger,
-        spinner: createSpinner(),
+        spinner,
       });
 
       logger.info('All dSYM files uploaded successfully.');
     } catch (error) {
+      spinner.stop();
       if (error instanceof UserFriendlyError) {
         // UserFriendlyError.message already contains the formatted string from formatCLIErrorMessage
         logger.error(error.message);

--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -171,8 +171,8 @@ sourcemapsCommand
         sourcemapsCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
       }
 
-      const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
       const spinner = createSpinner();
+      const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO, spinner);
       try {
         await runSourcemapUpload({ ...options, directory: options.path }, { logger, spinner });
       } catch (e) {

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -187,24 +187,18 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ].filter(([_, value]) => typeof value !== 'undefined'));
 
-    spinner.interrupt(() => {
-      logger.debug('Uploading %s', path);
-      logger.debug('PUT', url);
-    });
+    logger.debug('Uploading %s', path);
+    logger.debug('PUT', url);
 
     const dryRunUploadFile: typeof uploadFile = async () => {
-      spinner.interrupt( () => {
-        logger.info('sourceMapId %s would be used to upload %s', sourceMapId, path);
-      });
+      logger.info('sourceMapId %s would be used to upload %s', sourceMapId, path);
     };
     const uploadFileFn = options.dryRun ? dryRunUploadFile : uploadFile;
 
     // notify user if we cannot be certain the "sourcemaps inject" command was already run
     const alreadyInjected = await wasInjectAlreadyRun(path, logger);
     if (!alreadyInjected.result) {
-      spinner.interrupt(() => {
-        logger.warn(alreadyInjected.message);
-      });
+      logger.warn(alreadyInjected.message);
     }
 
     // upload a single file


### PR DESCRIPTION
spinner.interrupt functionality already existed, but it required code to manually use it.

createLogger now accepts a spinner, so any calls to such a logger will automatically go through spinner.interrupt for safe logging when a spinner is present

Before (the active spinner text "Uploading ..." stays in the console and jumbles some of the debug logs):
```
⠸ Uploading dist/multiErrorBundle.js.map | 37.7KB | 2 file(s) remainingDEBUG upload warning check: found source map pair (using standard naming convention)
DEBUG   - dist/clientBundle.js
DEBUG   - dist/clientBundle.js.map
WARN No sourceMapId was found in the related JavaScript file dist/clientBundle.js. Make sure to run the "sourcemaps inject" command in addition to "sourcemaps upload".  Use --help to learn more.
⠼ Uploading dist/multiErrorBundle.js.map | 37.7KB | 2 file(s) remainingDEBUG attachApiInterceptor called with full URL
```

After (the active spinner text "Uploading..." is no longer present after command is finished, and logs take up their own line as expected):
```
DEBUG upload warning check: found source map pair (using standard naming convention)
DEBUG   - dist/clientBundle.js
DEBUG   - dist/clientBundle.js.map
WARN No sourceMapId was found in the related JavaScript file dist/clientBundle.js. Make sure to run the "sourcemaps inject" command in addition to "sourcemaps upload".  Use --help to learn more.
DEBUG attachApiInterceptor called with full URL
```