### PR TITLE
Update domain from signalfx.com to observability.splunkcloud.com

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -28,7 +28,8 @@ import {
 import {
   BASE_URL_PREFIX,
   API_VERSION_STRING,
-  ANDROID_CONSTANTS
+  ANDROID_CONSTANTS,
+  DEFAULT_DOMAIN
 } from '../utils/constants';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { createLogger, LogLevel } from '../utils/logger';
@@ -42,7 +43,7 @@ import { attachApiInterceptor } from '../utils/apiInterceptor';
 export const androidCommand = new Command('android');
 
 const generateURL = (type: 'upload' | 'list', realm: string, appId: string, versionCode?: string, splunkBuildId?: string): string => {
-  const baseUrl = `${BASE_URL_PREFIX}.${realm}.signalfx.com/${API_VERSION_STRING}/${ANDROID_CONSTANTS.PATH_FOR_UPLOAD}`;
+  const baseUrl = `${BASE_URL_PREFIX}.${realm}.${DEFAULT_DOMAIN}/${API_VERSION_STRING}/${ANDROID_CONSTANTS.PATH_FOR_UPLOAD}`;
 
   if (type === 'upload') {
     if (!versionCode) throw new Error('Version code is required for uploading.');

--- a/src/dsyms/iOSdSYMUtils.ts
+++ b/src/dsyms/iOSdSYMUtils.ts
@@ -16,7 +16,7 @@
 
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
-import { BASE_URL_PREFIX, API_VERSION_STRING } from '../utils/constants';
+import { BASE_URL_PREFIX, API_VERSION_STRING, DEFAULT_DOMAIN } from '../utils/constants';
 import { Logger } from '../utils/logger';
 import { join, resolve, basename, dirname } from 'path';
 import { copyFileSync, mkdtempSync, readdirSync, rmSync, statSync } from 'fs';
@@ -28,7 +28,7 @@ import { UserFriendlyError, throwAsUserFriendlyErrnoException } from '../utils/u
 export const generateUrl = ({
   apiPath,
   realm,
-  domain = 'signalfx.com',
+  domain = DEFAULT_DOMAIN,
 }: {
   apiPath: string;
   realm: string;

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -23,7 +23,8 @@ import {
 import {
   BASE_URL_PREFIX,
   API_VERSION_STRING,
-  SOURCEMAPS_CONSTANTS
+  SOURCEMAPS_CONSTANTS,
+  DEFAULT_DOMAIN
 } from '../utils/constants';
 import { throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 import { discoverJsMapFilePath } from './discoverJsMapFilePath';
@@ -243,7 +244,7 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
 }
 
 function getSourceMapUploadUrl(realm: string, idPathParam: string): string {
-  const API_BASE_URL = `${BASE_URL_PREFIX}.${realm}.signalfx.com`;
+  const API_BASE_URL = `${BASE_URL_PREFIX}.${realm}.${DEFAULT_DOMAIN}`;
   const PATH_FOR_SOURCEMAPS = SOURCEMAPS_CONSTANTS.PATH_FOR_UPLOAD;
   return `${API_BASE_URL}/${API_VERSION_STRING}/${PATH_FOR_SOURCEMAPS}/id/${idPathParam}`;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,6 +23,10 @@ export const API_VERSION_STRING = 'v2';
 export const BASE_URL_PREFIX = 'https://api';
 export const TOKEN_HEADER = 'X-SF-Token';
 
+// Domain Constants
+export const DEFAULT_DOMAIN = 'observability.splunkcloud.com';
+export const LEGACY_DOMAIN = 'signalfx.com';
+
 // Android-Specific Constants
 export const ANDROID_CONSTANTS = {
   PATH_FOR_UPLOAD: 'rum-mfm/proguard',


### PR DESCRIPTION
Replace *.signalfx.com domain with *.observability.splunkcloud.com for API endpoints