### PR TITLE
Use main ref for official SAST scan template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ include:
     ref: master
     file: '/prodsec/.oss-scan.yml'
   - project: 'ci-cd/templates'
-    ref: master
+    ref: main
     file: '/prodsec/.sast-scan.yml'
 
 stages:


### PR DESCRIPTION
## Summary
- Changed the SAST `include` in `.gitlab-ci.yml` from `ref: master` to `ref: main` so it tracks the current official ProdSec template (`ci-cd/templates` → `/prodsec/.sast-scan.yml`).
- Resolves VULN ticket, `detect-unofficial-sast-template` finding was triggered by the outdated `master` ref (the project/file were already correct).
- `sast-scanner` job unchanged (still `extends: .sast_scan`, `alert_mode: "policy"`).

## Notes
- The `oss-scan` include is still on `ref: master`; left as-is since it's out of scope for this ticket.
